### PR TITLE
Fix GHCR public-access release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,10 @@ jobs:
             admin-server notification-service genai-service
             user-profile-service system-service audit-service
           )
+          accept_types="application/vnd.oci.image.index.v1+json"
+          accept_types+=",application/vnd.oci.image.manifest.v1+json"
+          accept_types+=",application/vnd.docker.distribution.manifest.list.v2+json"
+          accept_types+=",application/vnd.docker.distribution.manifest.v2+json"
           for service in "${services[@]}"; do
             token="$(
               curl --fail --silent --show-error \
@@ -141,7 +145,7 @@ jobs:
             )"
             curl --fail --silent --show-error \
               --header "Authorization: Bearer ${token}" \
-              --header "Accept: application/vnd.oci.image.index.v1+json" \
+              --header "Accept: ${accept_types}" \
               "https://ghcr.io/v2/${GITHUB_REPOSITORY_OWNER}/dentistdss-${service}/manifests/${BACKEND_TAG}" \
               >/dev/null
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,18 +116,17 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 
   publish-visibility:
-    name: Publish public package access
+    name: Verify public package access
     needs: publish
     if: github.event_name == 'push' && needs.publish.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      packages: write
+      contents: read
     steps:
-      - name: Make repository-linked images public
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify anonymous manifest access
         run: |
+          set -o errexit -o nounset -o pipefail
           services=(
             config-server discovery-server api-gateway auth-service
             clinic-service appointment-service clinical-records-service
@@ -135,10 +134,15 @@ jobs:
             user-profile-service system-service audit-service
           )
           for service in "${services[@]}"; do
-            gh api \
-              --method PATCH \
-              "/user/packages/container/dentistdss-${service}" \
-              --field visibility=public \
+            token="$(
+              curl --fail --silent --show-error \
+                "https://ghcr.io/token?scope=repository:${GITHUB_REPOSITORY_OWNER}/dentistdss-${service}:pull" |
+                jq --exit-status --raw-output '.token'
+            )"
+            curl --fail --silent --show-error \
+              --header "Authorization: Bearer ${token}" \
+              --header "Accept: application/vnd.oci.image.index.v1+json" \
+              "https://ghcr.io/v2/${GITHUB_REPOSITORY_OWNER}/dentistdss-${service}/manifests/${BACKEND_TAG}" \
               >/dev/null
           done
 


### PR DESCRIPTION
## Summary
- replace the unsupported GHCR visibility mutation with anonymous manifest verification
- verify all 13 immutable image tags can be pulled without credentials
- preserve the public-access gate before updating `gitops-dev`

## Root cause
The repository token published all images successfully, but GitHub returned HTTP 404 for the unsupported package-visibility API call. All 13 repository-linked packages are already public and return HTTP 200 anonymously.

## Verification
- `actionlint -color`
- `git diff --check`
- anonymous registry manifest requests returned HTTP 200 for all 13 images
