### PR TITLE
Fix GitOps promotion branch creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add deploy/chart/values-dev.yaml
           git commit -m "deploy: promote ${BACKEND_TAG} to dev [skip ci]"
-          git push --force origin HEAD:gitops-dev
+          git push --force origin HEAD:refs/heads/gitops-dev
 
   promote-production:
     name: Promote images to production GitOps
@@ -232,4 +232,4 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add deploy/chart/values-prod.yaml
           git commit -m "deploy: promote ${BACKEND_TAG} to production [skip ci]"
-          git push --force origin HEAD:gitops-prod
+          git push --force origin HEAD:refs/heads/gitops-prod


### PR DESCRIPTION
## Summary
- use fully qualified destination refs when creating machine-owned GitOps branches
- fix both automated dev promotion and gated production promotion

## Root cause
Git cannot infer a new remote branch namespace when the source is a detached commit. The destination must use `refs/heads/...`.

## Verification
- `actionlint -color`
- `git diff --check`
