### PR TITLE
Fix dev rollout startup configuration

### DIFF
--- a/admin-server/pom.xml
+++ b/admin-server/pom.xml
@@ -43,6 +43,11 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -53,4 +58,4 @@
             </plugin>
         </plugins>
     </build>
-</project> 
+</project>

--- a/admin-server/src/main/resources/application-docker.yml
+++ b/admin-server/src/main/resources/application-docker.yml
@@ -4,6 +4,8 @@ server:
 spring:
   application:
     name: admin-server
+  webflux:
+    base-path: /admin
   config:
     import: optional:configserver:http://${SPRING_CONFIG_USER}:${SPRING_CONFIG_PASS}@config-server:8888
 

--- a/admin-server/src/main/resources/application-prod.yml
+++ b/admin-server/src/main/resources/application-prod.yml
@@ -1,11 +1,11 @@
 server:
   port: 9090
-  servlet:
-    context-path: /admin
 
 spring:
   application:
     name: admin-server
+  webflux:
+    base-path: /admin
   config:
     import: optional:configserver:http://${SPRING_CONFIG_USER}:${SPRING_CONFIG_PASS}@config-server:8888
 

--- a/admin-server/src/main/resources/application.yml
+++ b/admin-server/src/main/resources/application.yml
@@ -1,11 +1,11 @@
 server:
   port: 9090
-  servlet:
-    context-path: /admin
 
 spring:
   application:
     name: admin-server
+  webflux:
+    base-path: /admin
   config:
     import: optional:configserver:http://localhost:8888
 
@@ -30,4 +30,4 @@ eureka:
     serviceUrl:
       defaultZone: ${EUREKA_URI:http://localhost:8761/eureka}
   instance:
-    preferIpAddress: false 
+    preferIpAddress: false

--- a/admin-server/src/test/java/press/mizhifei/dentist/admin/ConfigurationYamlTest.java
+++ b/admin-server/src/test/java/press/mizhifei/dentist/admin/ConfigurationYamlTest.java
@@ -1,0 +1,36 @@
+package press.mizhifei.dentist.admin;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigurationYamlTest {
+
+    private static final List<String> CONFIGURATIONS = List.of(
+            "application.yml",
+            "application-docker.yml",
+            "application-prod.yml");
+
+    @Test
+    void reactiveAdminBasePathIsConfiguredForEveryRuntimeProfile() throws IOException {
+        var loader = new YamlPropertySourceLoader();
+
+        for (String configuration : CONFIGURATIONS) {
+            List<PropertySource<?>> sources =
+                    loader.load(configuration, new ClassPathResource(configuration));
+
+            assertThat(sources)
+                    .as(configuration)
+                    .hasSize(1);
+            assertThat(sources.getFirst().getProperty("spring.webflux.base-path"))
+                    .as(configuration)
+                    .isEqualTo("/admin");
+        }
+    }
+}

--- a/appointment-service/src/main/resources/application-prod.yml
+++ b/appointment-service/src/main/resources/application-prod.yml
@@ -4,6 +4,11 @@
 
 server:
   port: 8089
+  error:
+    include-message: never
+    include-binding-errors: never
+    include-stacktrace: never
+    include-exception: false
 
 spring:
   application:
@@ -141,16 +146,6 @@ feign:
       min-request-size: 2048
     response:
       enabled: true
-
-# =============================================================================
-# Security Configuration
-# =============================================================================
-server:
-  error:
-    include-message: never
-    include-binding-errors: never
-    include-stacktrace: never
-    include-exception: false
 
 # =============================================================================
 # Application Specific Configuration

--- a/appointment-service/src/test/java/press/mizhifei/dentist/appointment/ConfigurationYamlTest.java
+++ b/appointment-service/src/test/java/press/mizhifei/dentist/appointment/ConfigurationYamlTest.java
@@ -1,0 +1,29 @@
+package press.mizhifei.dentist.appointment;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class ConfigurationYamlTest {
+
+    private static final List<String> CONFIGURATIONS = List.of(
+            "application.yml",
+            "application-docker.yml",
+            "application-prod.yml");
+
+    @Test
+    void configurationFilesContainValidYamlMappings() {
+        var loader = new YamlPropertySourceLoader();
+
+        for (String configuration : CONFIGURATIONS) {
+            var resource = new ClassPathResource(configuration);
+            assertThatCode(() -> loader.load(configuration, resource))
+                    .as(configuration)
+                    .doesNotThrowAnyException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- merge the duplicate `server` mapping in appointment production YAML
- configure the reactive Admin Server base path at `/admin`
- add regression tests for strict YAML loading and the Admin Server path contract

## Verification
- `git diff --check`
- GitHub Actions Java 21 verification (pending)

## Live failure evidence
- appointment-service: SnakeYAML `DuplicateKeyException` for `server`
- admin-server: `/actuator/health` returned 200 while the intended `/admin/actuator/health` probe returned 404