### PR TITLE
Allow Vercel frontend origins

### DIFF
--- a/api-gateway/src/main/resources/application-docker.yml
+++ b/api-gateway/src/main/resources/application-docker.yml
@@ -27,6 +27,8 @@ spring:
               '[/**]':
                 allowedOrigins:
                   - "https://dentist.mizhifei.press"
+                  - "https://dentistdss.vercel.app"
+                  - "https://dentistgpt.vercel.app"
                   - "https://accounts.google.com"
                 allowedMethods:
                   - GET

--- a/api-gateway/src/main/resources/application-prod.yml
+++ b/api-gateway/src/main/resources/application-prod.yml
@@ -27,6 +27,8 @@ spring:
               '[/**]':
                 allowedOrigins:
                   - "https://dentist.mizhifei.press"
+                  - "https://dentistdss.vercel.app"
+                  - "https://dentistgpt.vercel.app"
                   - "https://accounts.google.com"
                 allowedMethods:
                   - GET

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -27,6 +27,8 @@ spring:
               '[/**]':
                 allowedOrigins:
                   - "http://localhost:3000"
+                  - "https://dentistdss.vercel.app"
+                  - "https://dentistgpt.vercel.app"
                   - "https://accounts.google.com"
                 allowedMethods:
                   - GET
@@ -328,7 +330,6 @@ management:
       show-details: always
     gateway:
       access: READ_ONLY
-
 
 
 

--- a/auth-service/src/main/java/press/mizhifei/dentist/auth/security/OAuth2LoginSuccessHandler.java
+++ b/auth-service/src/main/java/press/mizhifei/dentist/auth/security/OAuth2LoginSuccessHandler.java
@@ -36,7 +36,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     private final OAuthUserService oAuthUserService;
 
-    @Value("${app.oauth2.authorizedRedirectUris:http://localhost:3000/oauth2/redirect,https://dentist.mizhifei.press/oauth2/redirect}")
+    @Value("${app.oauth2.authorizedRedirectUris:http://localhost:3000/oauth2/redirect,https://dentistdss.vercel.app/oauth2/redirect,https://dentistgpt.vercel.app/oauth2/redirect,https://dentist.mizhifei.press/oauth2/redirect}")
     private List<String> authorizedRedirectUris;
 
     @Override

--- a/auth-service/src/main/resources/application-docker.yml
+++ b/auth-service/src/main/resources/application-docker.yml
@@ -90,11 +90,12 @@ app:
   email-verification:
     token-expiry-minutes: 43200 # 30 days in minutes
     code-expiry-minutes: 10 # 10 minutes in minutes
-    base-url: ${BASE_URL:https://dentist.mizhifei.press}
+    base-url: ${BASE_URL:https://dentistdss.vercel.app}
   oauth2:
     authorizedRedirectUris:
+      - https://dentistdss.vercel.app/oauth2/redirect
+      - https://dentistgpt.vercel.app/oauth2/redirect
       - https://dentist.mizhifei.press/oauth2/redirect
       - http://localhost:3000/oauth2/redirect # Default for local React app
-
 
 

--- a/auth-service/src/main/resources/application-prod.yml
+++ b/auth-service/src/main/resources/application-prod.yml
@@ -89,7 +89,9 @@ app:
   email-verification:
     token-expiry-minutes: 43200 # 30 days in minutes
     code-expiry-minutes: 10 # 10 minutes in minutes
-    base-url: ${BASE_URL:https://dentist.mizhifei.press}
+    base-url: ${BASE_URL:https://dentistdss.vercel.app}
   oauth2:
     authorizedRedirectUris:
+      - https://dentistdss.vercel.app/oauth2/redirect
+      - https://dentistgpt.vercel.app/oauth2/redirect
       - https://dentist.mizhifei.press/oauth2/redirect

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -97,5 +97,7 @@ app:
     base-url: ${BASE_URL:http://localhost:3000}
   oauth2:
     authorizedRedirectUris:
+      - https://dentistdss.vercel.app/oauth2/redirect
+      - https://dentistgpt.vercel.app/oauth2/redirect
       - https://dentist.mizhifei.press/oauth2/redirect
       - http://localhost:3000/oauth2/redirect # Default for local React app

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -2,7 +2,7 @@ global:
   imageRegistry: ghcr.io/zhifeimi
   imageTag: bootstrap
   imagePullPolicy: IfNotPresent
-  publicBaseUrl: https://dentist.mizhifei.press
+  publicBaseUrl: https://dentistdss.vercel.app
 
 gateway:
   loadBalancerIP: ""
@@ -46,8 +46,10 @@ services:
     externalEgress: true
     env:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/dentistdss
-      BASE_URL: https://dentist.mizhifei.press
-      APP_OAUTH2_AUTHORIZEDREDIRECTURIS_0: https://dentist.mizhifei.press/oauth2/redirect
+      BASE_URL: https://dentistdss.vercel.app
+      APP_OAUTH2_AUTHORIZEDREDIRECTURIS_0: https://dentistdss.vercel.app/oauth2/redirect
+      APP_OAUTH2_AUTHORIZEDREDIRECTURIS_1: https://dentistgpt.vercel.app/oauth2/redirect
+      APP_OAUTH2_AUTHORIZEDREDIRECTURIS_2: https://dentist.mizhifei.press/oauth2/redirect
   clinic-service:
     port: 8083
     replicas: 1
@@ -84,7 +86,7 @@ services:
     externalEgress: true
     env:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/dentistdss
-      BASE_URL: https://dentist.mizhifei.press
+      BASE_URL: https://dentistdss.vercel.app
   appointment-service:
     port: 8089
     replicas: 1


### PR DESCRIPTION
## Summary
- allow both current and legacy Vercel production origins in API Gateway CORS
- make `dentistdss.vercel.app` the primary public URL for email links and OAuth
- retain `dentistgpt.vercel.app` and `dentist.mizhifei.press` as authorized OAuth redirect aliases
- render all aliases into the homelab chart

## Compatibility
- primary: `https://dentistdss.vercel.app`
- retained: `https://dentistgpt.vercel.app`
- retained future custom domain: `https://dentist.mizhifei.press`

## Verification
- Helm lint passed
- rendered dev chart contains all redirect URI environment entries
- `git diff --check`
- GitHub Actions Java 21 verification pending