### PR TITLE
fix: prevent config server self-import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,27 @@ jobs:
             >/tmp/dentistdss-prod.yaml
           test "$(grep -c '^kind: Deployment$' /tmp/dentistdss-dev.yaml)" -eq 12
           test "$(grep -c '^kind: Deployment$' /tmp/dentistdss-prod.yaml)" -eq 12
+          for manifest in /tmp/dentistdss-dev.yaml /tmp/dentistdss-prod.yaml; do
+            awk '
+              function validate_document() {
+                if (is_deployment && is_config_server && has_config_import) {
+                  print "config-server must not set SPRING_CONFIG_IMPORT" > "/dev/stderr"
+                  exit 1
+                }
+              }
+              /^---$/ {
+                validate_document()
+                is_deployment = 0
+                is_config_server = 0
+                has_config_import = 0
+                next
+              }
+              $0 == "kind: Deployment" { is_deployment = 1 }
+              $0 == "  name: config-server" { is_config_server = 1 }
+              $0 ~ /- name: SPRING_CONFIG_IMPORT$/ { has_config_import = 1 }
+              END { validate_document() }
+            ' "$manifest"
+          done
 
       - name: Validate deployment scripts
         run: bash -n deploy/scripts/*.sh

--- a/deploy/chart/templates/services.yaml
+++ b/deploy/chart/templates/services.yaml
@@ -1,6 +1,10 @@
 {{- range $name, $service := .Values.services }}
 {{- if or (not (hasKey $service "enabled")) $service.enabled }}
-{{- $environment := mergeOverwrite (deepCopy $.Values.commonEnv) ($service.env | default dict) }}
+{{- $commonEnvironment := deepCopy $.Values.commonEnv }}
+{{- if $service.configServer }}
+{{- $_ := unset $commonEnvironment "SPRING_CONFIG_IMPORT" }}
+{{- end }}
+{{- $environment := mergeOverwrite $commonEnvironment ($service.env | default dict) }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- omit `SPRING_CONFIG_IMPORT` from the config-server deployment while retaining it for client services
- add a deployment-contract regression check for both dev and prod Helm renders

## Root cause
The config server imported `http://config-server:8888` from its own common environment. Actuator health recursively requested `/application/default`, exhausted request threads, and caused liveness probe restarts.

## Verification
- `helm lint` for dev and prod values
- rendered both dev and prod manifests
- verified config-server has no `SPRING_CONFIG_IMPORT`
- verified client deployments retain the import
- workflow lint and `git diff --check`