### PR TITLE
fix: bound homelab database connection pools

### DIFF
--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -19,6 +19,8 @@ persistence:
 commonEnv:
   SPRING_PROFILES_ACTIVE: prod
   SPRING_CONFIG_IMPORT: optional:configserver:http://config-server:8888
+  SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "5"
+  SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "1"
   EUREKA_URI: http://discovery-server:8761/eureka
   LOGGING_FILE_NAME: /tmp/application.log
 

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -5,6 +5,8 @@ x-spring-environment: &spring-environment
   SPRING_CONFIG_IMPORT: optional:configserver:http://config-server:8888
   SPRING_CLOUD_CONFIG_USERNAME: ${SPRING_CONFIG_USER:?SPRING_CONFIG_USER is required}
   SPRING_CLOUD_CONFIG_PASSWORD: ${SPRING_CONFIG_PASS:?SPRING_CONFIG_PASS is required}
+  SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "5"
+  SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "1"
   EUREKA_URI: http://discovery-server:8761/eureka
   LOGGING_FILE_NAME: /tmp/application.log
 


### PR DESCRIPTION
## Summary
- cap Hikari pools at five connections per service
- keep one idle connection instead of eagerly filling each pool to its maximum
- apply the same budget to Helm and the canonical Compose deployment

## Root cause
Seven JDBC services defaulted to ten idle connections each. During simultaneous Kubernetes rolling updates, old and new pods exceeded PostgreSQL’s 100-client limit and two services restarted once with SQLSTATE 53300.

## Capacity
- steady-state maximum: 7 × 5 = 35 application connections
- rollout initialization: old pools plus one idle connection per new pod remain below the PostgreSQL limit

## Verification
- Compose model validation
- Helm lint and render for dev and prod
- rendered environment assertions
- `git diff --check`