### PR TITLE
[codex] reduce dev cluster memory pressure

### DIFF
--- a/admin-server/Dockerfile
+++ b/admin-server/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/admin-server-*.jar app.jar
 USER app
 EXPOSE 9090
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/api-gateway-*.jar app.jar
 USER app
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/appointment-service/Dockerfile
+++ b/appointment-service/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/appointment-service-*.jar app.jar
 USER app
 EXPOSE 8089
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/audit-service/Dockerfile
+++ b/audit-service/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/audit-service-*.jar app.jar
 USER app
 EXPOSE 8087
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/auth-service-*.jar app.jar
 USER app
 EXPOSE 8081
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/clinic-service/Dockerfile
+++ b/clinic-service/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/clinic-service-*.jar app.jar
 USER app
 EXPOSE 8083
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/clinical-records-service/Dockerfile
+++ b/clinical-records-service/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/clinical-records-service-*.jar app.jar
 USER app
 EXPOSE 8090
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/config-server-*.jar app.jar
 USER app
 EXPOSE 8888
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: dentistdss
 description: DentistDSS backend services for the homelab RKE2 clusters
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.9.2"

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -13,6 +13,9 @@ single-host fallback.
 - secret store: `ClusterSecretStore/homelab-vault`
 - registry: `ghcr.io/zhifeimi`
 - production ingress: Cloudflare Tunnel to `http://10.80.20.204:8080`
+- backend pods are spread across RKE2 nodes by hostname
+- dev uses non-surging rollouts, a 768 MiB Java container limit, and a 50% heap cap
+- application logs go to stdout; `/tmp` remains RAM-backed for temporary files
 
 The `bootstrap` image tag is intentionally non-runnable. The release workflow
 creates the GitOps branches only after all commit-SHA images exist and replaces

--- a/deploy/chart/templates/services.yaml
+++ b/deploy/chart/templates/services.yaml
@@ -40,6 +40,8 @@ metadata:
 spec:
   replicas: {{ $service.replicas }}
   revisionHistoryLimit: 3
+  strategy:
+    {{- toYaml $.Values.deploymentStrategy | nindent 4 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ $name }}
@@ -52,6 +54,16 @@ spec:
         app.kubernetes.io/part-of: dentistdss
         dentistdss.io/external-egress: {{ $service.externalEgress | default false | quote }}
     spec:
+      {{- if $.Values.topologySpread.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ $.Values.topologySpread.maxSkew }}
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: {{ $.Values.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ $.Release.Name }}
+              app.kubernetes.io/part-of: dentistdss
+      {{- end }}
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 45
       securityContext:

--- a/deploy/chart/values-dev.yaml
+++ b/deploy/chart/values-dev.yaml
@@ -8,6 +8,20 @@ gateway:
 externalSecrets:
   runtimePath: apps/dentistdss/dev/runtime
 
+commonEnv:
+  JAVA_TOOL_OPTIONS: -Xms64m -XX:MaxRAMPercentage=50.0 -XX:+ExitOnOutOfMemoryError
+
+deploymentStrategy:
+  rollingUpdate:
+    maxSurge: 0
+    maxUnavailable: 1
+
+javaResources:
+  requests:
+    memory: 384Mi
+  limits:
+    memory: 768Mi
+
 services:
   api-gateway:
     replicas: 1

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -22,7 +22,17 @@ commonEnv:
   SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "5"
   SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "1"
   EUREKA_URI: http://discovery-server:8761/eureka
-  LOGGING_FILE_NAME: /tmp/application.log
+
+deploymentStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
+topologySpread:
+  enabled: true
+  maxSkew: 1
+  whenUnsatisfiable: ScheduleAnyway
 
 services:
   config-server:

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/discovery-server-*.jar app.jar
 USER app
 EXPOSE 8761
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/genai-service/Dockerfile
+++ b/genai-service/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/genai-service-*.jar app.jar
 USER app
 EXPOSE 8084
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/notification-service-*.jar app.jar
 USER app
 EXPOSE 8088
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/system-service/Dockerfile
+++ b/system-service/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/system-service-*.jar app.jar
 USER app
 EXPOSE 8086
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/user-profile-service/Dockerfile
+++ b/user-profile-service/Dockerfile
@@ -12,4 +12,6 @@ COPY --chown=app:app target/user-profile-service-*.jar app.jar
 USER app
 EXPOSE 8085
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/app.jar"]
+ENV JAVA_TOOL_OPTIONS="-Xms64m -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
## What changed

- spread DentistDSS backend pods across RKE2 nodes by hostname
- use non-surging rolling updates in dev to avoid duplicate pods during releases
- set dev Java requests/limits to 384 MiB / 768 MiB
- apply a dev-only 50% JVM heap cap with a 64 MiB initial heap
- retain the existing 75% image default for production and non-Kubernetes use
- send Kubernetes application logs to stdout instead of RAM-backed `/tmp`
- bump the Helm chart version to 0.1.1

## Why

Live kubelet data showed DentistDSS using about 3.51 GiB on `rke2-dev-1`, with eleven JVMs concentrated on that node. The previous rollout strategy could also temporarily double pods during deployment. These changes reduce concentration and deployment peaks without reducing VM 280 from its configured 16 GB.

## Impact

Dev rollouts can briefly make an individual service unavailable because `maxSurge` is 0 and `maxUnavailable` is 1. Production retains zero-unavailable rolling updates and its existing 1 GiB container limit / 75% image heap default.

## Validation

- `helm lint deploy/chart --values deploy/chart/values-dev.yaml`
- `helm lint deploy/chart --values deploy/chart/values-prod.yaml`
- rendered and programmatically validated all 12 dev Deployments
- rendered and programmatically validated all 12 production Deployments
- verified dev/prod rollout and resource merges
- verified topology spread and removal of file logging
- verified all 13 service Dockerfiles expose overridable JVM options
- `bash -n deploy/scripts/*.sh`
- `git diff --check`
