### PR TITLE
security: scope DentistDSS Vault access

### DIFF
--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -10,7 +10,7 @@ single-host fallback.
 - dev namespace: `dev-dentistdss`, gateway address `10.80.30.204`
 - prod namespace: `prod-dentistdss`, gateway address `10.80.20.204`
 - storage class: `local-path`
-- secret store: `ClusterSecretStore/homelab-vault`
+- secret store: namespace `SecretStore/homelab-vault-dentistdss`
 - registry: `ghcr.io/zhifeimi`
 - production ingress: Cloudflare Tunnel to `http://10.80.20.204:8080`
 - backend pods are spread across RKE2 nodes by hostname
@@ -27,6 +27,11 @@ Create these KV v2 records:
 
 - `kv/apps/dentistdss/dev/runtime`
 - `kv/apps/dentistdss/prod/runtime`
+
+Each environment requires a `vault-dentistdss-token` Secret in its application
+namespace. The token must have read access only to that environment's runtime
+record. The chart creates the namespace-scoped SecretStore that consumes the
+token; never restore the former cluster-wide Vault store.
 
 Runtime records require:
 

--- a/deploy/chart/templates/config.yaml
+++ b/deploy/chart/templates/config.yaml
@@ -9,6 +9,28 @@ data:
 {{ .Files.Get "files/application.yml" | indent 4 }}
 ---
 apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: {{ .Values.externalSecrets.storeName }}
+  labels:
+    {{- include "dentistdss.labels" . | nindent 4 }}
+spec:
+  provider:
+    vault:
+      server: {{ required "externalSecrets.vaultServer is required" .Values.externalSecrets.vaultServer | quote }}
+      path: kv
+      version: v2
+      caProvider:
+        type: ConfigMap
+        name: vault-ca
+        namespace: external-secrets
+        key: ca.crt
+      auth:
+        tokenSecretRef:
+          name: {{ .Values.externalSecrets.tokenSecretName }}
+          key: token
+---
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: dentistdss-runtime
@@ -17,8 +39,8 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    kind: ClusterSecretStore
-    name: homelab-vault
+    kind: SecretStore
+    name: {{ .Values.externalSecrets.storeName }}
   target:
     name: dentistdss-runtime
     creationPolicy: Owner

--- a/deploy/chart/values-dev.yaml
+++ b/deploy/chart/values-dev.yaml
@@ -6,6 +6,7 @@ gateway:
   addressPool: pve-dev-services
 
 externalSecrets:
+  vaultServer: https://10.80.0.13:8200
   runtimePath: apps/dentistdss/dev/runtime
 
 commonEnv:

--- a/deploy/chart/values-prod.yaml
+++ b/deploy/chart/values-prod.yaml
@@ -6,4 +6,5 @@ gateway:
   addressPool: pve-prod-services
 
 externalSecrets:
+  vaultServer: https://10.80.0.13:8200
   runtimePath: apps/dentistdss/prod/runtime

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -9,6 +9,9 @@ gateway:
   addressPool: ""
 
 externalSecrets:
+  vaultServer: ""
+  storeName: homelab-vault-dentistdss
+  tokenSecretName: vault-dentistdss-token
   runtimePath: apps/dentistdss/dev/runtime
 
 persistence:

--- a/docs/HOMELAB_DEPLOYMENT_PLAN.md
+++ b/docs/HOMELAB_DEPLOYMENT_PLAN.md
@@ -86,7 +86,8 @@ application rollback must never silently reverse a schema migration.
 2. **Container release**: publish non-root, multi-architecture GHCR images and
    record image digests.
 3. **GitOps integration**: register the DentistDSS dev/prod Argo CD
-   applications, install the Vault ClusterSecretStore in both clusters, and
+   applications, provision an environment-scoped Vault policy and token Secret
+   for each namespace, let the chart install its namespace SecretStore, and
    create the machine-owned promotion branches.
 4. **Staging smoke test**: deploy to `pve-dev` with throwaway data, verify OAuth callbacks,
    email, PWA routing, every health endpoint, and restart persistence.


### PR DESCRIPTION
## Summary
- replace the removed cluster-wide Vault store with a namespace SecretStore
- authenticate through an environment-scoped token Secret
- retain the existing per-environment runtime KV paths

## Validation
- helm lint with dev values
- helm lint with prod values
- helm template verified SecretStore and ExternalSecret references
- Vault authorization matrix verified own path 200 and cross-environment/CI paths 403