### PR TITLE
security: run database pods as non-root

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -2,5 +2,6 @@ apiVersion: v2
 name: dentistdss
 description: DentistDSS backend services for the homelab RKE2 clusters
 type: application
+kubeVersion: ">=1.23.0-0"
 version: 0.1.1
 appVersion: "0.9.2"

--- a/deploy/chart/templates/databases.yaml
+++ b/deploy/chart/templates/databases.yaml
@@ -35,6 +35,11 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -70,6 +75,9 @@ spec:
             failureThreshold: 6
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             {{- toYaml .Values.databaseResources | nindent 12 }}
           volumeMounts:
@@ -122,6 +130,11 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -164,6 +177,9 @@ spec:
             failureThreshold: 6
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             {{- toYaml .Values.databaseResources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
## Summary
- run PostgreSQL as UID/GID 70 with matching fsGroup
- run MongoDB as UID/GID 999 with matching fsGroup
- drop all Linux capabilities on both database containers
- preserve RuntimeDefault seccomp and existing PVCs

## Validation
- helm lint with dev values
- helm lint with prod values
- helm template parsed as YAML
- rendered security contexts verified for both StatefulSets

This fixes PostgreSQL admission under the restricted Pod Security policy.